### PR TITLE
fix: support assigning the same image into multiple tracks

### DIFF
--- a/Editor/EditorPeriodicJob.cs
+++ b/Editor/EditorPeriodicJob.cs
@@ -95,14 +95,6 @@ namespace UnityEditor.StreamingImageSequence
 
         private static void ProcessStreamingImageSequenceTrack(StreamingImageSequenceTrack  track)
         {
-            //Check if we should hide the bound game object 
-            if (track.isEmpty) {
-                if (null != track.GetBoundGameObject()) {
-                    track.SetActiveBoundGameObject(false);
-                }
-                return;
-            }
-
             foreach (var clip in track.GetClips())
             {
                 var asset = clip.asset as StreamingImageSequencePlayableAsset;

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
@@ -62,6 +62,13 @@ namespace UnityEngine.StreamingImageSequence
             m_meshRenderer      = null;
         }
 
+//---------------------------------------------------------------------------------------------------------------------
+        public override void PrepareFrame(Playable playable, FrameData info) {
+            base.PrepareFrame(playable, info);
+            m_boundGameObject.SetActive(false); //Always hide first, and show it later 
+        }
+
+//---------------------------------------------------------------------------------------------------------------------
         public override void ProcessFrame(Playable playable, FrameData info, object playerData)
         {
             int inputCount = playable.GetInputCount<Playable>();
@@ -142,7 +149,9 @@ namespace UnityEngine.StreamingImageSequence
             }
 
             //Hide/Show
-            m_boundGameObject.SetActive(null != activeClip);
+            if (null != activeClip) {
+                m_boundGameObject.SetActive(true);
+            }
         }
 
         private void ProcessInAdvanceLoading(double time, TimelineClip clip, int index)

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequenceTrack.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequenceTrack.cs
@@ -42,8 +42,7 @@ namespace UnityEngine.StreamingImageSequence
                 bh.m_clips = GetClips();
                 if (outputGo != null)
                 {
-                    m_boundGameObject = outputGo.gameObject;
-                    bh.BindGameObject(m_boundGameObject);
+                    bh.BindGameObject(outputGo.gameObject);
                 }
                 bh.m_PlayableDirector = director;
 
@@ -51,17 +50,9 @@ namespace UnityEngine.StreamingImageSequence
             return mixer;
         }
 
-        public GameObject GetBoundGameObject() { return m_boundGameObject; } 
+
 
 //---------------------------------------------------------------------------------------------------------------------
-
-        public void SetActiveBoundGameObject(bool active) {
-            m_boundGameObject.SetActive(active);
-        }
-
-//---------------------------------------------------------------------------------------------------------------------
-
-        private GameObject m_boundGameObject = null;
 
     }
 


### PR DESCRIPTION
support assigning the same image into multiple tracks

Others:
- If the track is empty, then nothing will be done to the bound gameobject (reverting a bit of previous commit)