### PR TITLE
fix: AE import

### DIFF
--- a/Editor/AEConverter/JstimelineImporter.cs
+++ b/Editor/AEConverter/JstimelineImporter.cs
@@ -106,7 +106,6 @@ public class JstimelineImporter : ScriptedImporter
                     
                     string srcFilePath = Path.GetFullPath(Path.Combine(assetFolder, originalImagePaths[i])).Replace("\\", "/");
                     FileUtil.CopyFileOrDirectory(srcFilePath, destFilePath);
-                    AssetDatabase.ImportAsset(AssetEditorUtility.NormalizeAssetPath(destFilePath));
                 }
 
             }
@@ -173,6 +172,7 @@ public class JstimelineImporter : ScriptedImporter
 
         //cause crash if this is called inside of OnImportAsset()
         UnityEditor.EditorApplication.delayCall += () => {
+            AssetDatabase.Refresh();
             Selection.activeGameObject = director.gameObject;
         };
     }

--- a/Editor/StreamingImageSequencePlayableAssetInspector.cs
+++ b/Editor/StreamingImageSequencePlayableAssetInspector.cs
@@ -82,7 +82,7 @@ namespace UnityEditor.StreamingImageSequence {
             string newLoadPath = DrawFolderSelector ("Image Sequence", "Select Folder", 
                 prevFolder,
                 prevFolder,
-                NormalizeLoadPath
+                AssetEditorUtility.NormalizeAssetPath
             );
 
             if (newLoadPath != prevFolder) {
@@ -156,20 +156,6 @@ namespace UnityEditor.StreamingImageSequence {
             }
             return newDirPath;
         }        
-
-//---------------------------------------------------------------------------------------------------------------------
-
-        //Normalize so that the path is relative to the Unity root project
-        private static string NormalizeLoadPath(string path) {
-            if(!string.IsNullOrEmpty(path))
-            {
-                if (path.StartsWith(Application.dataPath))
-                {
-                    return path.Substring(Application.dataPath.Length - "Assets".Length);
-                }
-            }
-            return path;
-        }
 
 //---------------------------------------------------------------------------------------------------------------------
         private void DoImageGUI()

--- a/Editor/Utilities.meta
+++ b/Editor/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04f1906151bd751419aa9cf193c99a7b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utilities/AssetEditorUtility.cs
+++ b/Editor/Utilities/AssetEditorUtility.cs
@@ -12,6 +12,19 @@ public static class AssetEditorUtility {
         AssetDatabase.CreateAsset(asset, path);
     }
 
+//---------------------------------------------------------------------------------------------------------------------
+    //Normalize so that the path is relative to the Unity root project
+    public static string NormalizeAssetPath(string path) {
+        if (string.IsNullOrEmpty(path))
+            return null;
+
+        if (path.StartsWith(Application.dataPath)) {
+            return path.Substring(Application.dataPath.Length - "Assets".Length);
+        }
+        return path;
+    }
+
+
 }
 
 } //end namespace

--- a/Editor/Utilities/AssetEditorUtility.cs
+++ b/Editor/Utilities/AssetEditorUtility.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+using UnityEngine;
+
+namespace UnityEditor.StreamingImageSequence {
+
+public static class AssetEditorUtility {
+    public static void OverwriteAsset(Object asset, string path) {
+        if (File.Exists(path)) {
+            AssetDatabase.DeleteAsset(path);
+        }
+
+        AssetDatabase.CreateAsset(asset, path);
+    }
+
+}
+
+} //end namespace

--- a/Editor/Utilities/AssetEditorUtility.cs.meta
+++ b/Editor/Utilities/AssetEditorUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 408af1964903580408df091349effeef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
@@ -253,7 +253,7 @@ namespace UnityEngine.StreamingImageSequence
                 mat.mainTexture = tex; 
             } else if (null!= m_image) {
                 Sprite sprite = m_image.sprite;
-                if (sprite.texture != tex) {
+                if (null!=sprite && sprite.texture != tex) {
                     m_image.sprite = Sprite.Create(tex, new Rect(0.0f, 0.0f, tex.width, tex.height), new Vector2(0.5f, 0.5f), 100.0f, 1, SpriteMeshType.FullRect);
                 }
             }

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
@@ -253,7 +253,7 @@ namespace UnityEngine.StreamingImageSequence
                 mat.mainTexture = tex; 
             } else if (null!= m_image) {
                 Sprite sprite = m_image.sprite;
-                if (null!=sprite && sprite.texture != tex) {
+                if (null==sprite || sprite.texture != tex) {
                     m_image.sprite = Sprite.Create(tex, new Rect(0.0f, 0.0f, tex.width, tex.height), new Vector2(0.5f, 0.5f), 100.0f, 1, SpriteMeshType.FullRect);
                 }
             }

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
@@ -65,6 +65,9 @@ namespace UnityEngine.StreamingImageSequence
 //---------------------------------------------------------------------------------------------------------------------
         public override void PrepareFrame(Playable playable, FrameData info) {
             base.PrepareFrame(playable, info);
+            if (null == m_boundGameObject)
+                return;
+
             m_boundGameObject.SetActive(false); //Always hide first, and show it later 
         }
 

--- a/Runtime/Utilities/GameObjectExtensions.cs
+++ b/Runtime/Utilities/GameObjectExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace UnityEngine.StreamingImageSequence {
+
+public static class GameObjectExtensions {
+
+    public static T GetOrAddComponent<T>(this GameObject gameObject) where T : Component {
+        return gameObject.GetComponent<T>() ?? gameObject.AddComponent<T>();
+    }
+
+}
+
+} //end namespace

--- a/Runtime/Utilities/GameObjectExtensions.cs.meta
+++ b/Runtime/Utilities/GameObjectExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d791d9a182ba204dbd3c82c8cd17da8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
@@ -1,50 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5273483528170315701
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2a16748d9461eae46a725db9776d5390, type: 3}
-  m_Name: Markers
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips: []
-  m_Markers:
-    m_Objects: []
---- !u!114 &11400000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
-  m_Name: AeConvert_Timeline
-  m_EditorClassIdentifier: 
-  m_Version: 0
-  m_Tracks:
-  - {fileID: 114327062496350274}
-  - {fileID: 114200739938220932}
-  m_FixedDuration: 0
-  m_EditorSettings:
-    m_Framerate: 60
-  m_DurationMode: 0
-  m_MarkerTrack: {fileID: -5273483528170315701}
---- !u!114 &114200739938220932
+--- !u!114 &-7934451425175799719
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -68,10 +24,10 @@ MonoBehaviour:
   - m_Version: 1
     m_Start: 0
     m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: d8be1b00b9e427b4da1700b5d2f88260, type: 2}
+    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
     m_Duration: 0.9333333373069763
     m_TimeScale: 1
-    m_ParentTrack: {fileID: 114200739938220932}
+    m_ParentTrack: {fileID: -7934451425175799719}
     m_EaseInDuration: 0
     m_EaseOutDuration: 0
     m_BlendInDuration: 0
@@ -133,10 +89,10 @@ MonoBehaviour:
     m_PreExtrapolationMode: 0
     m_PostExtrapolationTime: 0
     m_PreExtrapolationTime: 0
-    m_DisplayName: MovieProxyPlayableAsset
+    m_DisplayName: StreamingImageSequencePlayableAsset
   m_Markers:
     m_Objects: []
---- !u!114 &114327062496350274
+--- !u!114 &-4772265245746404427
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -160,10 +116,10 @@ MonoBehaviour:
   - m_Version: 1
     m_Start: 0.7333333492279053
     m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: 8c323e0406140964e908c0b3b58250ca, type: 2}
+    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
     m_Duration: 1.9333332777023315
     m_TimeScale: 1
-    m_ParentTrack: {fileID: 114327062496350274}
+    m_ParentTrack: {fileID: -4772265245746404427}
     m_EaseInDuration: 0
     m_EaseOutDuration: 0
     m_BlendInDuration: 0
@@ -225,10 +181,31 @@ MonoBehaviour:
     m_PreExtrapolationMode: 0
     m_PostExtrapolationTime: 0
     m_PreExtrapolationTime: 0
-    m_DisplayName: MovieProxyPlayableAsset
+    m_DisplayName: StreamingImageSequencePlayableAsset
   m_Markers:
     m_Objects: []
---- !u!114 &114331955472603444
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: AeConvert_Timeline
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: -4772265245746404427}
+  - {fileID: -7934451425175799719}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!114 &1309265278413872894
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -238,7 +215,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: MovieProxyPlayableAsset
+  m_Name: StreamingImageSequencePlayableAsset
   m_EditorClassIdentifier: 
   Version: 0
   Resolution:
@@ -252,7 +229,7 @@ MonoBehaviour:
   m_folder: 
   m_imagePaths: []
   m_timelineDefaultAsset: {fileID: 0}
---- !u!114 &114361684351849680
+--- !u!114 &9157013874544490629
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -262,7 +239,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: MovieProxyPlayableAsset
+  m_Name: StreamingImageSequencePlayableAsset
   m_EditorClassIdentifier: 
   Version: 0
   Resolution:

--- a/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-7934451425175799719
+--- !u!114 &-6495665927435825864
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -9,90 +9,43 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_A
+  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_Name: StreamingImageSequencePlayableAsset
   m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips:
-  - m_Version: 1
-    m_Start: 0
-    m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
-    m_Duration: 0.9333333373069763
-    m_TimeScale: 1
-    m_ParentTrack: {fileID: -7934451425175799719}
-    m_EaseInDuration: 0
-    m_EaseOutDuration: 0
-    m_BlendInDuration: 0
-    m_BlendOutDuration: 0
-    m_MixInCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_MixOutCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_BlendInCurveMode: 0
-    m_BlendOutCurveMode: 0
-    m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 0}
-    m_Recordable: 0
-    m_PostExtrapolationMode: 0
-    m_PreExtrapolationMode: 0
-    m_PostExtrapolationTime: 0
-    m_PreExtrapolationTime: 0
-    m_DisplayName: StreamingImageSequencePlayableAsset
-  m_Markers:
-    m_Objects: []
---- !u!114 &-4772265245746404427
+  Version: 0
+  Resolution:
+    Width: 0
+    Height: 0
+  QuadSize:
+    sizX: 0
+    sizY: 0
+  m_displayOnClipsOnly: 0
+  m_loadingIndex: -1
+  m_folder: 
+  m_imagePaths: []
+  m_timelineDefaultAsset: {fileID: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: AeConvert_Timeline
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: 4147576518810310369}
+  - {fileID: 6731577149003596350}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!114 &4147576518810310369
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -119,7 +72,7 @@ MonoBehaviour:
     m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
     m_Duration: 1.9333332777023315
     m_TimeScale: 1
-    m_ParentTrack: {fileID: -4772265245746404427}
+    m_ParentTrack: {fileID: 4147576518810310369}
     m_EaseInDuration: 0
     m_EaseOutDuration: 0
     m_BlendInDuration: 0
@@ -184,28 +137,7 @@ MonoBehaviour:
     m_DisplayName: StreamingImageSequencePlayableAsset
   m_Markers:
     m_Objects: []
---- !u!114 &11400000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
-  m_Name: AeConvert_Timeline
-  m_EditorClassIdentifier: 
-  m_Version: 0
-  m_Tracks:
-  - {fileID: -4772265245746404427}
-  - {fileID: -7934451425175799719}
-  m_FixedDuration: 0
-  m_EditorSettings:
-    m_Framerate: 60
-  m_DurationMode: 0
-  m_MarkerTrack: {fileID: 0}
---- !u!114 &1309265278413872894
+--- !u!114 &4819997071269142321
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -229,7 +161,7 @@ MonoBehaviour:
   m_folder: 
   m_imagePaths: []
   m_timelineDefaultAsset: {fileID: 0}
---- !u!114 &9157013874544490629
+--- !u!114 &6731577149003596350
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -238,18 +170,86 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: StreamingImageSequencePlayableAsset
+  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
+  m_Name: Footage_A
   m_EditorClassIdentifier: 
-  Version: 0
-  Resolution:
-    Width: 0
-    Height: 0
-  QuadSize:
-    sizX: 0
-    sizY: 0
-  m_displayOnClipsOnly: 0
-  m_loadingIndex: -1
-  m_folder: 
-  m_imagePaths: []
-  m_timelineDefaultAsset: {fileID: 0}
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0
+    m_ClipIn: 0
+    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
+    m_Duration: 0.9333333373069763
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 6731577149003596350}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 0}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: StreamingImageSequencePlayableAsset
+  m_Markers:
+    m_Objects: []

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: Footage_A_MovieProxy
+  m_Name: Footage_A_StreamingImageSequence
   m_EditorClassIdentifier: 
   Version: 0
   Resolution:
-    Width: 0
-    Height: 0
+    Width: 1684
+    Height: 1050
   QuadSize:
     sizX: 0
     sizY: 0
   m_displayOnClipsOnly: 1
-  m_loadingIndex: 28
-  m_folder: Assets/StreamingAssets/Footage_A
+  m_loadingIndex: -1
+  m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_A
   m_imagePaths:
   - A_00000.png
   - A_00001.png
@@ -51,5 +51,4 @@ MonoBehaviour:
   - A_00025.png
   - A_00026.png
   - A_00027.png
-  m_timelineDefaultAsset: {fileID: 102900000, guid: 03c7029848f532949bbbc4d26c7915b1,
-    type: 3}
+  m_timelineDefaultAsset: {fileID: 0}

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable.meta
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8c323e0406140964e908c0b3b58250ca
+guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: Footage_B_MovieProxy
+  m_Name: Footage_B_StreamingImageSequence
   m_EditorClassIdentifier: 
   Version: 0
   Resolution:
-    Width: 0
-    Height: 0
+    Width: 1684
+    Height: 1000
   QuadSize:
     sizX: 0
     sizY: 0
   m_displayOnClipsOnly: 1
-  m_loadingIndex: 58
-  m_folder: Assets/StreamingAssets/Footage_B
+  m_loadingIndex: -1
+  m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_B
   m_imagePaths:
   - B_00000.png
   - B_00001.png
@@ -81,5 +81,4 @@ MonoBehaviour:
   - B_00055.png
   - B_00056.png
   - B_00057.png
-  m_timelineDefaultAsset: {fileID: 102900000, guid: 8bcebc0ffe2c86e4f82055b17b71d654,
-    type: 3}
+  m_timelineDefaultAsset: {fileID: 0}

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable.meta
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d8be1b00b9e427b4da1700b5d2f88260
+guid: daf0dcc75467c20419f275ba7a3b1f0f
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000


### PR DESCRIPTION
- Support relative paths when importing jstimeline
- Overwrite existing assets when the same jstimeline is imported