### PR TITLE
feat: trimming/splitting TimelineClip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ StreamingImageSequence~/*.csproj
 StreamingImageSequence~/*.csproj.meta
 StreamingImageSequence~/*.sln
 StreamingImageSequence~/.idea/**
+StreamingImageSequence~.meta
+StreamingImageSequence~/Assets.meta
 .vs/
 Library/
 Temp/

--- a/.yamato/upm-ci-StreamingImageSequence.yml
+++ b/.yamato/upm-ci-StreamingImageSequence.yml
@@ -9,7 +9,7 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
 ---
 pack:

--- a/Editor/AEConverter/JstimelineImporter.cs
+++ b/Editor/AEConverter/JstimelineImporter.cs
@@ -180,6 +180,7 @@ public class JstimelineImporter : ScriptedImporter
                                                   trackMovieContainer.Resolution.Height);
 
             director.SetGenericBinding(movieTrack, renderer);
+            EditorUtility.SetDirty(director);
         }
 
         //cause crash if this is called inside of OnImportAsset()

--- a/Editor/AEConverter/JstimelineImporter.cs
+++ b/Editor/AEConverter/JstimelineImporter.cs
@@ -106,7 +106,7 @@ public class JstimelineImporter : ScriptedImporter
                 string destFolder = Application.streamingAssetsPath;
                 destFolder = Path.Combine(destFolder, strFootageName).Replace("\\", "/");
                 Directory.CreateDirectory(destFolder); //make sure the directory exists
-                trackMovieContainer.Folder = destFolder;
+                trackMovieContainer.Folder = AssetEditorUtility.NormalizeAssetPath(destFolder);
 
                 for (int i=0;i<numImages;++i) {
                     string destFilePath = Path.Combine(destFolder, trackMovieContainer.Pictures[i]);

--- a/Editor/AEConverter/JstimelineImporter.cs
+++ b/Editor/AEConverter/JstimelineImporter.cs
@@ -121,17 +121,20 @@ public class JstimelineImporter : ScriptedImporter
             }
 
 
-            StreamingImageSequencePlayableAsset proxyAsset = ScriptableObject.CreateInstance<StreamingImageSequencePlayableAsset>();
-            proxyAsset.SetParam(trackMovieContainer);
+            StreamingImageSequencePlayableAsset sisAsset = ScriptableObject.CreateInstance<StreamingImageSequencePlayableAsset>();
+            sisAsset.SetParam(trackMovieContainer);
 
             string playableAssetPath = Path.Combine(timelineFolder, strFootageName + "_StreamingImageSequence.playable");
-            AssetEditorUtility.OverwriteAsset(proxyAsset, playableAssetPath);
+            AssetEditorUtility.OverwriteAsset(sisAsset, playableAssetPath);
 
             StreamingImageSequenceTrack movieTrack = asset.CreateTrack<StreamingImageSequenceTrack>(null, strFootageName);
             TimelineClip clip = movieTrack.CreateDefaultClip();
-            clip.asset = proxyAsset;
+            clip.asset = sisAsset;
             clip.start = track.Start;
             clip.duration = track.Duration;
+            sisAsset.Setup(clip);
+            sisAsset.ValidateAnimationCurve();
+
 
             if (Object.FindObjectOfType(typeof(UnityEngine.EventSystems.EventSystem)) == null)
             {

--- a/Editor/StreamingImageSequencePlayableAssetEditor.cs
+++ b/Editor/StreamingImageSequencePlayableAssetEditor.cs
@@ -71,11 +71,13 @@ namespace UnityEngine.StreamingImageSequence {
                 return false;
             }
 
-
             ImageSequenceImporter.ImportPictureFiles(PictureFileImporterParam.Mode.StreamingAssets, path, asset);
-            clip.duration = asset.GetImagePaths().Count * 0.125; // 8fps (standard limited animation)
-            clip.displayName = Path.GetFileName(asset.GetFolder());
-            clip.CreateCurves("Curves: " + clip.displayName);
+            //If the clip already has curves (because of cloning, etc), then we don't set anything
+            if (null == clip.curves) {
+                clip.duration = asset.GetImagePaths().Count * 0.125; // 8fps (standard limited animation)
+                clip.displayName = Path.GetFileName(asset.GetFolder());
+                clip.CreateCurves("Curves: " + clip.displayName);
+            }
 
             asset.Setup(clip);
             asset.ValidateAnimationCurve();

--- a/Editor/StreamingImageSequencePlayableAssetEditor.cs
+++ b/Editor/StreamingImageSequencePlayableAssetEditor.cs
@@ -78,7 +78,7 @@ namespace UnityEngine.StreamingImageSequence {
             clip.CreateCurves("Curves: " + clip.displayName);
 
             asset.Setup(clip);
-            asset.SetDuration(clip.duration);
+            asset.ValidateAnimationCurve();
             return true;
         }
 

--- a/Editor/StreamingImageSequencePlayableAssetEditor.cs
+++ b/Editor/StreamingImageSequencePlayableAssetEditor.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.StreamingImageSequence {
 
                 UnityEditor.DefaultAsset timelineDefaultAsset = asset.GetTimelineDefaultAsset();
                 if (null!=timelineDefaultAsset) {
-                    if (!InitializeAssetFromDefaultAsset(clip, asset)) {
+                    if (!InitializeAssetFromDefaultAsset(clip, null, asset)) {
                         clipOptions.errorText = kNotStreamingAssetsFolderAssignedError;
                     }
                 } else {
@@ -57,21 +57,26 @@ namespace UnityEngine.StreamingImageSequence {
                 return;
             }
 
-            InitializeAssetFromDefaultAsset(clip, asset);
+            InitializeAssetFromDefaultAsset(clip, clonedFrom, asset);
         }
-       
-        private static bool InitializeAssetFromDefaultAsset(TimelineClip clip, StreamingImageSequencePlayableAsset asset) 
-        {
-            UnityEditor.DefaultAsset timelineDefaultAsset = asset.GetTimelineDefaultAsset();
-            if (null == timelineDefaultAsset)
-                return false;
 
-            string path = AssetDatabase.GetAssetPath(timelineDefaultAsset).Replace("\\","/");
-            if (!path.StartsWith("Assets/StreamingAssets/")) {
-                return false;
+//----------------------------------------------------------------------------------------------------------------------
+
+        private static bool InitializeAssetFromDefaultAsset(TimelineClip clip, TimelineClip clonedFrom, 
+            StreamingImageSequencePlayableAsset asset) 
+        {
+            if (null == clonedFrom) { //Not cloning, which means this is created by user interaction, such as Folder D&D
+                UnityEditor.DefaultAsset timelineDefaultAsset = asset.GetTimelineDefaultAsset();
+                if (null == timelineDefaultAsset)
+                    return false;
+
+                string path = AssetDatabase.GetAssetPath(timelineDefaultAsset).Replace("\\","/");
+                if (!path.StartsWith("Assets/StreamingAssets/")) {
+                    return false;
+                }
+                ImageSequenceImporter.ImportPictureFiles(PictureFileImporterParam.Mode.StreamingAssets, path, asset);
             }
 
-            ImageSequenceImporter.ImportPictureFiles(PictureFileImporterParam.Mode.StreamingAssets, path, asset);
             //If the clip already has curves (because of cloning, etc), then we don't set anything
             if (null == clip.curves) {
                 clip.duration = asset.GetImagePaths().Count * 0.125; // 8fps (standard limited animation)

--- a/Editor/StreamingImageSequencePlayableAssetEditor.cs
+++ b/Editor/StreamingImageSequencePlayableAssetEditor.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using System.IO;
 using UnityEditor;
 using UnityEditor.StreamingImageSequence;
@@ -74,6 +75,10 @@ namespace UnityEngine.StreamingImageSequence {
             ImageSequenceImporter.ImportPictureFiles(PictureFileImporterParam.Mode.StreamingAssets, path, asset);
             clip.duration = asset.GetImagePaths().Count * 0.125; // 8fps (standard limited animation)
             clip.displayName = Path.GetFileName(asset.GetFolder());
+            clip.CreateCurves("Curves: " + clip.displayName);
+
+            asset.Setup(clip);
+            asset.SetDuration(clip.duration);
             return true;
         }
 

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -305,6 +305,9 @@ namespace UnityEngine.StreamingImageSequence {
         public void Setup(TimelineClip clip) {
             clip.OnTimingSet     = OnClipTimingSet;
             clip.OnTimingTrimmed = OnClipTimingTrimmed;
+            if (null == clip.curves) {
+                clip.CreateCurves("Curves: " + clip.displayName);
+            }
             m_timelineClip = clip;
             m_clipStart = clip.start;
             m_clipDuration = clip.duration;

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -68,12 +68,21 @@ namespace UnityEngine.StreamingImageSequence {
             Reset();
         }
 //----------------------------------------------------------------------------------------------------------------------        
+        //Calculate Image Sequence Time, which is normalized [0..1] 
+        public double ToImageSequenceTime(double globalTime) {
+            double localTime = m_timelineClip.ToLocalTime(globalTime);
+            AnimationCurve curve = GetAndValidateAnimationCurve();
+            return curve.Evaluate((float)localTime);
+        }
+//----------------------------------------------------------------------------------------------------------------------
 
         public int GetVersion() { return m_version; }
         public IList<string> GetImagePaths() { return m_imagePaths; }
         public ImageDimensionInt GetResolution() { return m_resolution; }
         public System.Collections.IList GetImagePathsNonGeneric() { return m_imagePaths; }
         public Texture2D GetTexture() { return m_texture; }
+
+//----------------------------------------------------------------------------------------------------------------------        
 
         public string GetImagePath(int index) {
             if (null == m_imagePaths || index >= m_imagePaths.Count)

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -101,8 +101,10 @@ namespace UnityEngine.StreamingImageSequence {
 //----------------------------------------------------------------------------------------------------------------------        
 
         public ClipCaps clipCaps {
-            get { return ClipCaps.None; }
+            get { return ClipCaps.ClipIn | ClipCaps.SpeedMultiplier; }
         }
+        
+//----------------------------------------------------------------------------------------------------------------------        
 
         public bool Verified
         {
@@ -299,8 +301,6 @@ namespace UnityEngine.StreamingImageSequence {
 //---------------------------------------------------------------------------------------------------------------------
         
         public void Setup(TimelineClip clip) {
-            clip.OnTimingSet     = OnClipTimingSet;
-            clip.OnTimingTrimmed = OnClipTimingTrimmed;
             if (null == clip.curves) {
                 clip.CreateCurves("Curves: " + clip.displayName);
             }
@@ -353,59 +353,6 @@ namespace UnityEngine.StreamingImageSequence {
 #endif            
         }
 
-//---------------------------------------------------------------------------------------------------------------------
-
-        void OnClipTimingSet(double st, double dur) {
-            AnimationCurve curve = GetAndValidateAnimationCurve();
-            m_clipStart = st;
-            m_clipDuration = dur;
-            
-            Keyframe[] keys = curve.keys;
-            int lastKeyIndex = keys.Length - 1;
-            
-            //[TODO-sin: 2019-12-26] Calculate new positions/tangents of middle keys
-            //for (int i = 1; i < lastKeyIndex; ++i) {
-            //}
-           
-            
-            //Make sure the last keyframe is located at the duration time
-            keys[lastKeyIndex].time  = (float) m_clipDuration;
-            
-            //Fix the tangent of the last key
-            double valueDiff = keys[lastKeyIndex].value - keys[lastKeyIndex-1].value;
-            double timeDiff = keys[lastKeyIndex].time - keys[lastKeyIndex-1].time;
-            float tangent = (float) (valueDiff / dur);
-            keys[lastKeyIndex - 1].outTangent = tangent;
-            keys[lastKeyIndex].inTangent = tangent;
-            
-            curve.keys = keys;
-            RefreshAnimationCurve(curve);
-        }
-
-//---------------------------------------------------------------------------------------------------------------------
-        void OnClipTimingTrimmed(double st, double dur) {
-            AnimationCurve curve = GetAndValidateAnimationCurve();
-            double prevDur = m_clipDuration;
-            double prevStart = m_clipStart;
-            m_clipStart = st;
-            m_clipDuration = dur;
-            
-            //double localStart = m_timelineClip.ToLocalTime(st);
-            double localStartTime   = (st - prevStart);
-            float startVal = curve.Evaluate((float) localStartTime);
-            float endVal = curve.Evaluate((float) (localStartTime + dur));
-            
-            //[TODO-sin: 2019-12-26] Calculate new tangents
-            
-            Keyframe[] keys = curve.keys;
-            int lastKeyIndex = keys.Length - 1;
-            
-            keys[0].value = startVal;
-            keys[lastKeyIndex].time = (float) m_clipDuration;
-            keys[lastKeyIndex].value = endVal;
-            curve.keys = keys;
-            RefreshAnimationCurve(curve);
-        }
         
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -352,11 +352,24 @@ namespace UnityEngine.StreamingImageSequence {
             m_clipStart = st;
             m_clipDuration = dur;
             
-            //[TODO-sin: 2019-12-25] Calculate new tangents
+            Keyframe[] keys = curve.keys;
+            int lastKeyIndex = keys.Length - 1;
+            
+            //[TODO-sin: 2019-12-26] Calculate new positions/tangents of middle keys
+            //for (int i = 1; i < lastKeyIndex; ++i) {
+            //}
+           
             
             //Make sure the last keyframe is located at the duration time
-            Keyframe[] keys = curve.keys;
-            keys[keys.Length - 1].time  = (float) m_clipDuration;
+            keys[lastKeyIndex].time  = (float) m_clipDuration;
+            
+            //Fix the tangent of the last key
+            double valueDiff = keys[lastKeyIndex].value - keys[lastKeyIndex-1].value;
+            double timeDiff = keys[lastKeyIndex].time - keys[lastKeyIndex-1].time;
+            float tangent = (float) (valueDiff / dur);
+            keys[lastKeyIndex - 1].outTangent = tangent;
+            keys[lastKeyIndex].inTangent = tangent;
+            
             curve.keys = keys;
             RefreshAnimationCurve(curve);
         }

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -13,11 +13,6 @@ namespace UnityEngine.StreamingImageSequence {
     //ITimelineClipAsset interface is used to define the clip capabilities (ClipCaps) 
     [System.Serializable]
     public class StreamingImageSequencePlayableAsset : PlayableAsset, ITimelineClipAsset, IPlayableBehaviour {
-//----------------------------------------------------------------------------------------------------------------------        
-        public StreamingImageSequencePlayableAsset() {
-            m_loadingIndex = -1;
-            m_lastIndex = -1;
-        }
         
 //----------------------------------------------------------------------------------------------------------------------
         public virtual void OnBehaviourDelay(Playable playable, FrameData info) {
@@ -55,6 +50,7 @@ namespace UnityEngine.StreamingImageSequence {
 
         public StreamingImageSequencePlayableAsset() {
             m_loadingIndex = -1;
+            m_lastIndex = -1;
 #if UNITY_EDITOR            
             m_timelineEditorCurveBinding  = new EditorCurveBinding() {
                 path = "",

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableMixer.cs
@@ -125,9 +125,8 @@ namespace UnityEngine.StreamingImageSequence
 
                 if (directorTime >= startTime && directorTime < endTime) {
                     activeClip = clip;
-                    float rate = (float)(directorTime - startTime);
-                    float now = (float)count * (float)rate / (float)clipDuration;
-                    int index = (int)now;
+                    double imageSequenceTime = asset.ToImageSequenceTime(directorTime);
+                    int index = (int)(count * imageSequenceTime);
                     if (index < 0) {
                         index = 0;
                     }

--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequenceTrack.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequenceTrack.cs
@@ -50,7 +50,18 @@ namespace UnityEngine.StreamingImageSequence
             return mixer;
         }
 
+//---------------------------------------------------------------------------------------------------------------------
 
+        protected override  void OnAfterTrackDeserialize() {
+            //Re-setup the PlayableAsset
+            foreach (TimelineClip clip in m_Clips) {
+                StreamingImageSequencePlayableAsset playableAsset = clip.asset as StreamingImageSequencePlayableAsset;
+                if (null == playableAsset)
+                    continue;
+                
+                playableAsset.Setup(clip);
+            }
+        }
 
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/Runtime/Unity.StreamingImageSequence.asmdef
+++ b/Runtime/Unity.StreamingImageSequence.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Unity.StreamingImageSequence",
     "references": [
-        "GUID:f06555f75b070af458a003d92f9efb00"
+        "GUID:f06555f75b070af458a003d92f9efb00",
+        "GUID:02f771204943f4a40949438e873e3eff"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -10,5 +11,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
@@ -1,167 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6495665927435825864
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: StreamingImageSequencePlayableAsset
-  m_EditorClassIdentifier: 
-  Version: 0
-  Resolution:
-    Width: 0
-    Height: 0
-  QuadSize:
-    sizX: 0
-    sizY: 0
-  m_displayOnClipsOnly: 0
-  m_loadingIndex: -1
-  m_folder: 
-  m_imagePaths: []
-  m_timelineDefaultAsset: {fileID: 0}
---- !u!114 &11400000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
-  m_Name: AeConvert_Timeline
-  m_EditorClassIdentifier: 
-  m_Version: 0
-  m_Tracks:
-  - {fileID: 4147576518810310369}
-  - {fileID: 6731577149003596350}
-  m_FixedDuration: 0
-  m_EditorSettings:
-    m_Framerate: 60
-  m_DurationMode: 0
-  m_MarkerTrack: {fileID: 0}
---- !u!114 &4147576518810310369
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_B
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips:
-  - m_Version: 1
-    m_Start: 0.7333333492279053
-    m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
-    m_Duration: 1.9333332777023315
-    m_TimeScale: 1
-    m_ParentTrack: {fileID: 4147576518810310369}
-    m_EaseInDuration: 0
-    m_EaseOutDuration: 0
-    m_BlendInDuration: 0
-    m_BlendOutDuration: 0
-    m_MixInCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_MixOutCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_BlendInCurveMode: 0
-    m_BlendOutCurveMode: 0
-    m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 0}
-    m_Recordable: 0
-    m_PostExtrapolationMode: 0
-    m_PreExtrapolationMode: 0
-    m_PostExtrapolationTime: 0
-    m_PreExtrapolationTime: 0
-    m_DisplayName: StreamingImageSequencePlayableAsset
-  m_Markers:
-    m_Objects: []
---- !u!114 &4819997071269142321
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_Name: StreamingImageSequencePlayableAsset
-  m_EditorClassIdentifier: 
-  Version: 0
-  Resolution:
-    Width: 0
-    Height: 0
-  QuadSize:
-    sizX: 0
-    sizY: 0
-  m_displayOnClipsOnly: 0
-  m_loadingIndex: -1
-  m_folder: 
-  m_imagePaths: []
-  m_timelineDefaultAsset: {fileID: 0}
---- !u!114 &6731577149003596350
+--- !u!114 &-5912727629429169184
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -188,7 +27,7 @@ MonoBehaviour:
     m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
     m_Duration: 0.9333333373069763
     m_TimeScale: 1
-    m_ParentTrack: {fileID: 6731577149003596350}
+    m_ParentTrack: {fileID: -5912727629429169184}
     m_EaseInDuration: 0
     m_EaseOutDuration: 0
     m_BlendInDuration: 0
@@ -244,7 +83,376 @@ MonoBehaviour:
     m_BlendInCurveMode: 0
     m_BlendOutCurveMode: 0
     m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 0}
+    m_AnimationCurves: {fileID: 1013381091047476834}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: StreamingImageSequencePlayableAsset
+  m_Markers:
+    m_Objects: []
+--- !u!114 &-4137198824069403584
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_Name: StreamingImageSequencePlayableAsset
+  m_EditorClassIdentifier: 
+  m_folder: 
+  m_imagePaths: []
+  m_version: 1
+  m_resolution:
+    Width: 0
+    Height: 0
+  m_time: 0
+  m_timelineDefaultAsset: {fileID: 0}
+  m_loadingIndex: -1
+--- !u!74 &-2680167559709953791
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
+  serializedVersion: 6
+  m_Legacy: 1
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0.5172414
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1.9333333
+        value: 1
+        inSlope: 0.5172414
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.9333333
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0.5172414
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1.9333333
+        value: 1
+        inSlope: 0.5172414
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: AeConvert_Timeline
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: 5268978068366489872}
+  - {fileID: -5912727629429169184}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!74 &1013381091047476834
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
+  serializedVersion: 6
+  m_Legacy: 1
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 1.0714285
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.93333334
+        value: 1
+        inSlope: 1.0714285
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.93333334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 1.0714285
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.93333334
+        value: 1
+        inSlope: 1.0714285
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!114 &1265330780376870971
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_Name: StreamingImageSequencePlayableAsset
+  m_EditorClassIdentifier: 
+  m_folder: 
+  m_imagePaths: []
+  m_version: 1
+  m_resolution:
+    Width: 0
+    Height: 0
+  m_time: 0
+  m_timelineDefaultAsset: {fileID: 0}
+  m_loadingIndex: -1
+--- !u!114 &5268978068366489872
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
+  m_Name: Footage_B
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0.7333333492279053
+    m_ClipIn: 0
+    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
+    m_Duration: 1.9333332777023315
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 5268978068366489872}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: -2680167559709953791}
     m_Recordable: 0
     m_PostExtrapolationMode: 0
     m_PreExtrapolationMode: 0

--- a/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
@@ -1,190 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-8307775202691749493
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_B
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips:
-  - m_Version: 1
-    m_Start: 0.7333333492279053
-    m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
-    m_Duration: 1.9333332777023315
-    m_TimeScale: 1
-    m_ParentTrack: {fileID: -8307775202691749493}
-    m_EaseInDuration: 0
-    m_EaseOutDuration: 0
-    m_BlendInDuration: 0
-    m_BlendOutDuration: 0
-    m_MixInCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_MixOutCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_BlendInCurveMode: 0
-    m_BlendOutCurveMode: 0
-    m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 7538349927893468196}
-    m_Recordable: 0
-    m_PostExtrapolationMode: 0
-    m_PreExtrapolationMode: 0
-    m_PostExtrapolationTime: 0
-    m_PreExtrapolationTime: 0
-    m_DisplayName: StreamingImageSequencePlayableAsset
-  m_Markers:
-    m_Objects: []
---- !u!114 &-8060828561878000272
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_A
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips:
-  - m_Version: 1
-    m_Start: 0
-    m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
-    m_Duration: 0.9333333373069763
-    m_TimeScale: 1
-    m_ParentTrack: {fileID: -8060828561878000272}
-    m_EaseInDuration: 0
-    m_EaseOutDuration: 0
-    m_BlendInDuration: 0
-    m_BlendOutDuration: 0
-    m_MixInCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_MixOutCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    m_BlendInCurveMode: 0
-    m_BlendOutCurveMode: 0
-    m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 2332706939032207523}
-    m_Recordable: 0
-    m_PostExtrapolationMode: 0
-    m_PreExtrapolationMode: 0
-    m_PostExtrapolationTime: 0
-    m_PreExtrapolationTime: 0
-    m_DisplayName: StreamingImageSequencePlayableAsset
-  m_Markers:
-    m_Objects: []
---- !u!114 &-5431090711891538817
+--- !u!114 &-6474410757745256057
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -219,46 +35,61 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Version: 0
   m_Tracks:
-  - {fileID: -8307775202691749493}
-  - {fileID: -8060828561878000272}
+  - {fileID: 368010206315998828}
+  - {fileID: 4000436665306141348}
   m_FixedDuration: 0
   m_EditorSettings:
     m_Framerate: 60
   m_DurationMode: 0
   m_MarkerTrack: {fileID: 0}
---- !u!74 &2332706939032207523
-AnimationClip:
-  m_ObjectHideFlags: 0
+--- !u!114 &368010206315998828
+MonoBehaviour:
+  m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
-  serializedVersion: 6
-  m_Legacy: 1
-  m_Compressed: 0
-  m_UseHighQualityCurve: 1
-  m_RotationCurves: []
-  m_CompressedRotationCurves: []
-  m_EulerCurves: []
-  m_PositionCurves: []
-  m_ScaleCurves: []
-  m_FloatCurves:
-  - curve:
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
+  m_Name: Footage_B
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0.7333333492279053
+    m_ClipIn: 0
+    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
+    m_Duration: 1.9333332777023315
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 368010206315998828}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
         value: 0
         inSlope: 0
-        outSlope: 1.0714285
+        outSlope: 0
         tangentMode: 0
         weightedMode: 0
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 0.93333334
+        time: 1
         value: 1
-        inSlope: 1.0714285
+        inSlope: 0
         outSlope: 0
         tangentMode: 0
         weightedMode: 0
@@ -267,56 +98,22 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_time
-    path: 
-    classID: 114
-    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_PPtrCurves: []
-  m_SampleRate: 60
-  m_WrapMode: 0
-  m_Bounds:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
-  m_AnimationClipSettings:
-    serializedVersion: 2
-    m_AdditiveReferencePoseClip: {fileID: 0}
-    m_AdditiveReferencePoseTime: 0
-    m_StartTime: 0
-    m_StopTime: 0.93333334
-    m_OrientationOffsetY: 0
-    m_Level: 0
-    m_CycleOffset: 0
-    m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
-    m_LoopBlend: 0
-    m_LoopBlendOrientation: 0
-    m_LoopBlendPositionY: 0
-    m_LoopBlendPositionXZ: 0
-    m_KeepOriginalOrientation: 0
-    m_KeepOriginalPositionY: 1
-    m_KeepOriginalPositionXZ: 0
-    m_HeightFromFeet: 0
-    m_Mirror: 0
-  m_EditorCurves:
-  - curve:
+    m_MixOutCurve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: 1
         inSlope: 0
-        outSlope: 1.0714285
+        outSlope: 0
         tangentMode: 0
         weightedMode: 0
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 0.93333334
-        value: 1
-        inSlope: 1.0714285
+        time: 1
+        value: 0
+        inSlope: 0
         outSlope: 0
         tangentMode: 0
         weightedMode: 0
@@ -325,15 +122,19 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_time
-    path: 
-    classID: 114
-    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_EulerEditorCurves: []
-  m_HasGenericRootTransform: 0
-  m_HasMotionFloatCurves: 0
-  m_Events: []
---- !u!114 &2876659582339763529
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 5618769135900191444}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: StreamingImageSequencePlayableAsset
+  m_Markers:
+    m_Objects: []
+--- !u!114 &3757114275505863527
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -354,7 +155,99 @@ MonoBehaviour:
   m_time: 0
   m_timelineDefaultAsset: {fileID: 0}
   m_loadingIndex: -1
---- !u!74 &7538349927893468196
+--- !u!114 &4000436665306141348
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
+  m_Name: Footage_A
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0
+    m_ClipIn: 0
+    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
+    m_Duration: 0.9333333373069763
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 4000436665306141348}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 7536909172388180373}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: StreamingImageSequencePlayableAsset
+  m_Markers:
+    m_Objects: []
+--- !u!74 &5618769135900191444
 AnimationClip:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -445,6 +338,113 @@ AnimationClip:
         time: 1.9333333
         value: 1
         inSlope: 0.5172414
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!74 &7536909172388180373
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
+  serializedVersion: 6
+  m_Legacy: 1
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 1.0714285
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.93333334
+        value: 1
+        inSlope: 1.0714285
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.93333334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 1.0714285
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.93333334
+        value: 1
+        inSlope: 1.0714285
         outSlope: 0
         tangentMode: 0
         weightedMode: 0

--- a/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/AeConvert_Timeline.playable
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5912727629429169184
+--- !u!114 &-8307775202691749493
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_A
+  m_Name: Footage_B
   m_EditorClassIdentifier: 
   m_Version: 3
   m_AnimClip: {fileID: 0}
@@ -22,12 +22,12 @@ MonoBehaviour:
   m_Children: []
   m_Clips:
   - m_Version: 1
-    m_Start: 0
+    m_Start: 0.7333333492279053
     m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
-    m_Duration: 0.9333333373069763
+    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
+    m_Duration: 1.9333332777023315
     m_TimeScale: 1
-    m_ParentTrack: {fileID: -5912727629429169184}
+    m_ParentTrack: {fileID: -8307775202691749493}
     m_EaseInDuration: 0
     m_EaseOutDuration: 0
     m_BlendInDuration: 0
@@ -83,7 +83,7 @@ MonoBehaviour:
     m_BlendInCurveMode: 0
     m_BlendOutCurveMode: 0
     m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: 1013381091047476834}
+    m_AnimationCurves: {fileID: 7538349927893468196}
     m_Recordable: 0
     m_PostExtrapolationMode: 0
     m_PreExtrapolationMode: 0
@@ -92,7 +92,99 @@ MonoBehaviour:
     m_DisplayName: StreamingImageSequencePlayableAsset
   m_Markers:
     m_Objects: []
---- !u!114 &-4137198824069403584
+--- !u!114 &-8060828561878000272
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
+  m_Name: Footage_A
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0
+    m_ClipIn: 0
+    m_Asset: {fileID: 11400000, guid: 00d7bfb1dd76e824ebfdd3dd7366ee1d, type: 2}
+    m_Duration: 0.9333333373069763
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: -8060828561878000272}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 2332706939032207523}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: StreamingImageSequencePlayableAsset
+  m_Markers:
+    m_Objects: []
+--- !u!114 &-5431090711891538817
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -113,113 +205,6 @@ MonoBehaviour:
   m_time: 0
   m_timelineDefaultAsset: {fileID: 0}
   m_loadingIndex: -1
---- !u!74 &-2680167559709953791
-AnimationClip:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
-  serializedVersion: 6
-  m_Legacy: 1
-  m_Compressed: 0
-  m_UseHighQualityCurve: 1
-  m_RotationCurves: []
-  m_CompressedRotationCurves: []
-  m_EulerCurves: []
-  m_PositionCurves: []
-  m_ScaleCurves: []
-  m_FloatCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0.5172414
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1.9333333
-        value: 1
-        inSlope: 0.5172414
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_time
-    path: 
-    classID: 114
-    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_PPtrCurves: []
-  m_SampleRate: 60
-  m_WrapMode: 0
-  m_Bounds:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 0, y: 0, z: 0}
-  m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
-  m_AnimationClipSettings:
-    serializedVersion: 2
-    m_AdditiveReferencePoseClip: {fileID: 0}
-    m_AdditiveReferencePoseTime: 0
-    m_StartTime: 0
-    m_StopTime: 1.9333333
-    m_OrientationOffsetY: 0
-    m_Level: 0
-    m_CycleOffset: 0
-    m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
-    m_LoopBlend: 0
-    m_LoopBlendOrientation: 0
-    m_LoopBlendPositionY: 0
-    m_LoopBlendPositionXZ: 0
-    m_KeepOriginalOrientation: 0
-    m_KeepOriginalPositionY: 1
-    m_KeepOriginalPositionXZ: 0
-    m_HeightFromFeet: 0
-    m_Mirror: 0
-  m_EditorCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0.5172414
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 1.9333333
-        value: 1
-        inSlope: 0.5172414
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_time
-    path: 
-    classID: 114
-    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
-  m_EulerEditorCurves: []
-  m_HasGenericRootTransform: 0
-  m_HasMotionFloatCurves: 0
-  m_Events: []
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,14 +219,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Version: 0
   m_Tracks:
-  - {fileID: 5268978068366489872}
-  - {fileID: -5912727629429169184}
+  - {fileID: -8307775202691749493}
+  - {fileID: -8060828561878000272}
   m_FixedDuration: 0
   m_EditorSettings:
     m_Framerate: 60
   m_DurationMode: 0
   m_MarkerTrack: {fileID: 0}
---- !u!74 &1013381091047476834
+--- !u!74 &2332706939032207523
 AnimationClip:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -348,7 +333,7 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events: []
---- !u!114 &1265330780376870971
+--- !u!114 &2876659582339763529
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -369,54 +354,39 @@ MonoBehaviour:
   m_time: 0
   m_timelineDefaultAsset: {fileID: 0}
   m_loadingIndex: -1
---- !u!114 &5268978068366489872
-MonoBehaviour:
-  m_ObjectHideFlags: 1
+--- !u!74 &7538349927893468196
+AnimationClip:
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 588b3cca60f217d438ef96013ebfdb06, type: 3}
-  m_Name: Footage_B
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_AnimClip: {fileID: 0}
-  m_Locked: 0
-  m_Muted: 0
-  m_CustomPlayableFullTypename: 
-  m_Curves: {fileID: 0}
-  m_Parent: {fileID: 11400000}
-  m_Children: []
-  m_Clips:
-  - m_Version: 1
-    m_Start: 0.7333333492279053
-    m_ClipIn: 0
-    m_Asset: {fileID: 11400000, guid: daf0dcc75467c20419f275ba7a3b1f0f, type: 2}
-    m_Duration: 1.9333332777023315
-    m_TimeScale: 1
-    m_ParentTrack: {fileID: 5268978068366489872}
-    m_EaseInDuration: 0
-    m_EaseOutDuration: 0
-    m_BlendInDuration: 0
-    m_BlendOutDuration: 0
-    m_MixInCurve:
+  m_Name: 'Curves: StreamingImageSequencePlayableAsset'
+  serializedVersion: 6
+  m_Legacy: 1
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
         value: 0
         inSlope: 0
-        outSlope: 0
+        outSlope: 0.5172414
         tangentMode: 0
         weightedMode: 0
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 1
+        time: 1.9333333
         value: 1
-        inSlope: 0
+        inSlope: 0.5172414
         outSlope: 0
         tangentMode: 0
         weightedMode: 0
@@ -425,22 +395,56 @@ MonoBehaviour:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    m_MixOutCurve:
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.9333333
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
+        value: 0
         inSlope: 0
-        outSlope: 0
+        outSlope: 0.5172414
         tangentMode: 0
         weightedMode: 0
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 1
-        value: 0
-        inSlope: 0
+        time: 1.9333333
+        value: 1
+        inSlope: 0.5172414
         outSlope: 0
         tangentMode: 0
         weightedMode: 0
@@ -449,15 +453,11 @@ MonoBehaviour:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    m_BlendInCurveMode: 0
-    m_BlendOutCurveMode: 0
-    m_ExposedParameterNames: []
-    m_AnimationCurves: {fileID: -2680167559709953791}
-    m_Recordable: 0
-    m_PostExtrapolationMode: 0
-    m_PreExtrapolationMode: 0
-    m_PostExtrapolationTime: 0
-    m_PreExtrapolationTime: 0
-    m_DisplayName: StreamingImageSequencePlayableAsset
-  m_Markers:
-    m_Objects: []
+    attribute: m_time
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
   m_Name: Footage_A_StreamingImageSequence
   m_EditorClassIdentifier: 
-  m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_A
+  m_folder: Assets/StreamingAssets/Footage_A
   m_imagePaths:
   - A_00000.png
   - A_00001.png
@@ -47,5 +47,6 @@ MonoBehaviour:
     Width: 1684
     Height: 1050
   m_time: 0
-  m_timelineDefaultAsset: {fileID: 0}
+  m_timelineDefaultAsset: {fileID: 102900000, guid: 03c7029848f532949bbbc4d26c7915b1,
+    type: 3}
   m_loadingIndex: -1

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_A_StreamingImageSequence.playable
@@ -12,15 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
   m_Name: Footage_A_StreamingImageSequence
   m_EditorClassIdentifier: 
-  Version: 0
-  Resolution:
-    Width: 1684
-    Height: 1050
-  QuadSize:
-    sizX: 0
-    sizY: 0
-  m_displayOnClipsOnly: 1
-  m_loadingIndex: -1
   m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_A
   m_imagePaths:
   - A_00000.png
@@ -51,4 +42,10 @@ MonoBehaviour:
   - A_00025.png
   - A_00026.png
   - A_00027.png
+  m_version: 1
+  m_resolution:
+    Width: 1684
+    Height: 1050
+  m_time: 0
   m_timelineDefaultAsset: {fileID: 0}
+  m_loadingIndex: -1

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
@@ -12,15 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
   m_Name: Footage_B_StreamingImageSequence
   m_EditorClassIdentifier: 
-  Version: 0
-  Resolution:
-    Width: 1684
-    Height: 1000
-  QuadSize:
-    sizX: 0
-    sizY: 0
-  m_displayOnClipsOnly: 1
-  m_loadingIndex: -1
   m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_B
   m_imagePaths:
   - B_00000.png
@@ -81,4 +72,10 @@ MonoBehaviour:
   - B_00055.png
   - B_00056.png
   - B_00057.png
+  m_version: 1
+  m_resolution:
+    Width: 1684
+    Height: 1000
+  m_time: 0
   m_timelineDefaultAsset: {fileID: 0}
+  m_loadingIndex: -1

--- a/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
+++ b/StreamingImageSequence~/Assets/AeConvert/Footage_B_StreamingImageSequence.playable
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07c579aa4480ce64daff0ad6a9312d97, type: 3}
   m_Name: Footage_B_StreamingImageSequence
   m_EditorClassIdentifier: 
-  m_folder: E:/G/unity3d-jp/StreamingImageSequence/StreamingImageSequence~/Assets/StreamingAssets/Footage_B
+  m_folder: Assets/StreamingAssets/Footage_B
   m_imagePaths:
   - B_00000.png
   - B_00001.png
@@ -77,5 +77,6 @@ MonoBehaviour:
     Width: 1684
     Height: 1000
   m_time: 0
-  m_timelineDefaultAsset: {fileID: 0}
+  m_timelineDefaultAsset: {fileID: 102900000, guid: 8bcebc0ffe2c86e4f82055b17b71d654,
+    type: 3}
   m_loadingIndex: -1

--- a/StreamingImageSequence~/Assets/Tests.meta
+++ b/StreamingImageSequence~/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12b82e774f9a4054dbd9f813262b2dad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StreamingImageSequence~/Assets/Tests/Editor.meta
+++ b/StreamingImageSequence~/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fff4d13da123728488edf2d93044c221
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef
+++ b/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef
@@ -4,7 +4,8 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:8ce817a30579cb44d9c5a62807fd9fd5",
-        "GUID:83bf442171810a04381b4d745b2fdb72"
+        "GUID:83bf442171810a04381b4d745b2fdb72",
+        "GUID:f06555f75b070af458a003d92f9efb00"
     ],
     "includePlatforms": [
         "Editor"

--- a/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef
+++ b/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "EditorTests",
+    "references": [
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:8ce817a30579cb44d9c5a62807fd9fd5",
+        "GUID:83bf442171810a04381b4d745b2fdb72"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": []
+}

--- a/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef.meta
+++ b/StreamingImageSequence~/Assets/Tests/Editor/EditorTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a67cdc86a69ed134187426869f420421
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs
+++ b/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.StreamingImageSequence;
+
+
+namespace Tests {
+    public class SampleSceneTest {
+        [Test]
+        public void PlayableAssetValidityPass() {           
+            string[] playableAssetPaths = {
+                "Assets/AeConvert/Footage_A_StreamingImageSequence.playable",
+                "Assets/AeConvert/Footage_B_StreamingImageSequence.playable",
+            };
+
+            foreach (string path in playableAssetPaths) {
+                StreamingImageSequencePlayableAsset playableAsset = AssetDatabase.LoadAssetAtPath<StreamingImageSequencePlayableAsset>(path);
+                Assert.IsNotNull(playableAsset);
+                Assert.IsTrue(playableAsset.GetFolder().StartsWith("Assets/"));
+            }
+        }
+
+    }
+}

--- a/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs
+++ b/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs
@@ -1,7 +1,11 @@
 using NUnit.Framework;
+using System.IO;
 using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.Playables;
 using UnityEngine.StreamingImageSequence;
-
+using UnityEngine.Timeline;
 
 namespace Tests {
     public class SampleSceneTest {
@@ -19,5 +23,27 @@ namespace Tests {
             }
         }
 
+//---------------------------------------------------------------------------------------------------------------------
+        [Test]
+        public void SampleSceneValidityPass() {           
+            string sampleScenePath = "Assets/Scenes/defaultSample.unity";
+            Assert.IsTrue(File.Exists(sampleScenePath));
+            EditorSceneManager.OpenScene(sampleScenePath);
+
+            PlayableDirector[] pds = Object.FindObjectsOfType<PlayableDirector>(); 
+            foreach (PlayableDirector pd in pds) {
+                PlayableAsset playableAsset = pd.playableAsset;
+
+                if (!(playableAsset is TimelineAsset)) {
+                    continue;
+                }
+
+                TimelineAsset timelineAsset = playableAsset as TimelineAsset;
+                foreach (TrackAsset trackAsset in timelineAsset.GetOutputTracks()) {
+                    //Make sure the Image is bound to the trackAsset
+                    Assert.IsNotNull(pd.GetGenericBinding(trackAsset));
+                }
+            }
+        }
     }
 }

--- a/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs.meta
+++ b/StreamingImageSequence~/Assets/Tests/Editor/SampleSceneTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15567089ce6c8c548957d7c3c15904de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Trimming Start/End of TimelineClip
* Splitting TimelineClip
* Calculate frame index based on time
* Add tests for the sample scene to ensure its validity

Bug fixes:
* Fix bug which causes the objects bound to the PlayableDirector not saved 
* Fix importing when using jstimeline. (Unnormalized folder)