### PR TITLE
fix: prevent the internal texture from being destroyed when TimelineEditor is refreshed

### DIFF
--- a/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
+++ b/Runtime/PlayableAssets/StreamingImageSequence/StreamingImageSequencePlayableAsset.cs
@@ -62,9 +62,10 @@ namespace UnityEngine.StreamingImageSequence {
         }
         /// <inheritdoc/>
         public void OnPlayableDestroy(Playable playable){
-            //Destroy hidden resources
-            ResetTexture();
+            //[Note-sin: 2020-9-8] OnPlayableDestroy() will be called when TimelineEditor is refreshed
+            //(ContentsAddedOrRemoved or ContentsModified) 
         }
+        
 
         /// <inheritdoc/>
         public void PrepareFrame(Playable playable, FrameData info){


### PR DESCRIPTION
 OnPlayableDestroy() will be called when TimelineEditor is refreshed, which is causing the recipients of the texture (Image, etc) 
 to be blank