### PR TITLE
fix: ImageFolderPlayableAsset image errors when Unity gets into focus

### DIFF
--- a/Runtime/Scripts/Features/ImageFolderPlayableAsset.cs
+++ b/Runtime/Scripts/Features/ImageFolderPlayableAsset.cs
@@ -142,7 +142,7 @@ internal abstract class ImageFolderPlayableAsset : BaseTimelineClipSISDataPlayab
 
         List<WatchedFileInfo> newImageFiles  = FindImages(m_folder);
         int                   numNewImages   = newImageFiles.Count;
-        int                   numPrevImages  = m_imageFiles.Count;
+        int                   numPrevImages  = GetNumImages();
         bool                  changed        = false;
 
         //Check if we need to unload prev images, and detect change


### PR DESCRIPTION
Happens when the following two conditions are met.
1. There is no image inside ImageFolderPlayableAsset
2. Unity gets back in focus after going out of focus
