### PR TITLE
fix: try to create the saved path RenderCachePlayableAsset if invalid

### DIFF
--- a/Editor/Scripts/Features/RenderCache/RenderCachePlayableAssetInspector.cs
+++ b/Editor/Scripts/Features/RenderCache/RenderCachePlayableAssetInspector.cs
@@ -360,15 +360,32 @@ internal class RenderCachePlayableAssetInspector : UnityEditor.Editor {
     private void ValidateAssetFolder() {
 
         string folder = m_asset.GetFolder();
-        if (!string.IsNullOrEmpty(folder) && Directory.Exists(folder)) {            
-            return;
+        if (!string.IsNullOrEmpty(folder)) {
+            
+            if (Directory.Exists(folder))           
+                return;
+            
+            try {
+                Directory.CreateDirectory(folder);
+                return;
+            } catch {
+                //Fallback to the below code
+            }
         }
-        
+
+        AssignDefaultAssetFolder();
+                
+    }
+
+//----------------------------------------------------------------------------------------------------------------------
+
+    private void AssignDefaultAssetFolder() {
         string assetName = string.IsNullOrEmpty(m_asset.name) ? "RenderCachePlayableAsset" : m_asset.name;               
         //Generate unique folder
         string baseFolder = Path.Combine(Application.streamingAssetsPath, assetName);
-        folder = PathUtility.GenerateUniqueFolder(baseFolder); 
+        string folder = PathUtility.GenerateUniqueFolder(baseFolder); 
         m_asset.SetFolder(AssetUtility.NormalizeAssetPath(folder).Replace('\\','/'));
+        Repaint();        
     }
     
 //----------------------------------------------------------------------------------------------------------------------

--- a/Editor/Scripts/Features/RenderCache/RenderCachePlayableAssetInspector.cs
+++ b/Editor/Scripts/Features/RenderCache/RenderCachePlayableAssetInspector.cs
@@ -368,7 +368,7 @@ internal class RenderCachePlayableAssetInspector : UnityEditor.Editor {
         //Generate unique folder
         string baseFolder = Path.Combine(Application.streamingAssetsPath, assetName);
         folder = PathUtility.GenerateUniqueFolder(baseFolder); 
-        m_asset.SetFolder(AssetUtility.NormalizeAssetPath(folder));
+        m_asset.SetFolder(AssetUtility.NormalizeAssetPath(folder).Replace('\\','/'));
     }
     
 //----------------------------------------------------------------------------------------------------------------------

--- a/StreamingImageSequence_HDRP~/Assets/Scenes/PencilLineScene/PencilLineDirector.playable
+++ b/StreamingImageSequence_HDRP~/Assets/Scenes/PencilLineScene/PencilLineDirector.playable
@@ -289,7 +289,127 @@ MonoBehaviour:
   m_Markers:
     m_Objects: []
   m_serializedSISDataCollection:
-  - m_playableFrames: []
+  - m_playableFrames:
+    - m_serializedBoolProperties: []
+      m_localTime: 0
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.016666666666666666
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.03333333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.05
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.06666666666666667
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.08333333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.1
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.11666666666666667
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.13333333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.15
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.16666666666666666
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.18333333333333332
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.2
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.21666666666666667
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.23333333333333334
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.25
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.26666666666666666
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.2833333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.3
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.31666666666666665
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.3333333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.35
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.36666666666666664
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.3833333333333333
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.4
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.4166666666666667
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.43333333333333335
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.45
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.4666666666666667
+      m_marker: {fileID: 0}
+      m_userNote: 
+    - m_serializedBoolProperties: []
+      m_localTime: 0.48333333333333334
+      m_marker: {fileID: 0}
+      m_userNote: 
     m_frameMarkersRequested: 0
     m_version: 0
 --- !u!114 &-221817260743349573
@@ -753,7 +873,211 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 37a40b7a45cc745d08253d44b20ff862, type: 3}
   m_Name: RenderCachePlayableAsset
   m_EditorClassIdentifier: 
-  m_folder: 
+  m_folder: Assets/StreamingAssets/RenderCacheScene
   m_imageFileNames: []
-  m_folderMD5: 
-  m_version: 1
+  m_imageFiles:
+  - m_name: RenderCacheScene_000.png
+    m_size: 48716
+  - m_name: RenderCacheScene_001.png
+    m_size: 48829
+  - m_name: RenderCacheScene_002.png
+    m_size: 49076
+  - m_name: RenderCacheScene_003.png
+    m_size: 49020
+  - m_name: RenderCacheScene_004.png
+    m_size: 48901
+  - m_name: RenderCacheScene_005.png
+    m_size: 48798
+  - m_name: RenderCacheScene_006.png
+    m_size: 48920
+  - m_name: RenderCacheScene_007.png
+    m_size: 49142
+  - m_name: RenderCacheScene_008.png
+    m_size: 49198
+  - m_name: RenderCacheScene_009.png
+    m_size: 49311
+  - m_name: RenderCacheScene_010.png
+    m_size: 49176
+  - m_name: RenderCacheScene_011.png
+    m_size: 49482
+  - m_name: RenderCacheScene_012.png
+    m_size: 49609
+  - m_name: RenderCacheScene_013.png
+    m_size: 49672
+  - m_name: RenderCacheScene_014.png
+    m_size: 49689
+  - m_name: RenderCacheScene_015.png
+    m_size: 49648
+  - m_name: RenderCacheScene_016.png
+    m_size: 49619
+  - m_name: RenderCacheScene_017.png
+    m_size: 50083
+  - m_name: RenderCacheScene_018.png
+    m_size: 50025
+  - m_name: RenderCacheScene_019.png
+    m_size: 50469
+  - m_name: RenderCacheScene_020.png
+    m_size: 50497
+  - m_name: RenderCacheScene_021.png
+    m_size: 50360
+  - m_name: RenderCacheScene_022.png
+    m_size: 50549
+  - m_name: RenderCacheScene_023.png
+    m_size: 50498
+  - m_name: RenderCacheScene_024.png
+    m_size: 50450
+  - m_name: RenderCacheScene_025.png
+    m_size: 50676
+  - m_name: RenderCacheScene_026.png
+    m_size: 50387
+  - m_name: RenderCacheScene_027.png
+    m_size: 50866
+  - m_name: RenderCacheScene_028.png
+    m_size: 50764
+  - m_name: RenderCacheScene_029.png
+    m_size: 50885
+  - m_name: RenderCacheScene_030.png
+    m_size: 51296
+  - m_name: RenderCacheScene_031.png
+    m_size: 50961
+  - m_name: RenderCacheScene_032.png
+    m_size: 50744
+  - m_name: RenderCacheScene_033.png
+    m_size: 50340
+  - m_name: RenderCacheScene_034.png
+    m_size: 50431
+  - m_name: RenderCacheScene_035.png
+    m_size: 51393
+  - m_name: RenderCacheScene_036.png
+    m_size: 51611
+  - m_name: RenderCacheScene_037.png
+    m_size: 51158
+  - m_name: RenderCacheScene_038.png
+    m_size: 50979
+  - m_name: RenderCacheScene_039.png
+    m_size: 51244
+  - m_name: RenderCacheScene_040.png
+    m_size: 51258
+  - m_name: RenderCacheScene_041.png
+    m_size: 51350
+  - m_name: RenderCacheScene_042.png
+    m_size: 51240
+  - m_name: RenderCacheScene_043.png
+    m_size: 51386
+  - m_name: RenderCacheScene_044.png
+    m_size: 51442
+  - m_name: RenderCacheScene_045.png
+    m_size: 51774
+  - m_name: RenderCacheScene_046.png
+    m_size: 51704
+  - m_name: RenderCacheScene_047.png
+    m_size: 51704
+  - m_name: RenderCacheScene_048.png
+    m_size: 51319
+  - m_name: RenderCacheScene_049.png
+    m_size: 51046
+  - m_name: RenderCacheScene_050.png
+    m_size: 50946
+  - m_name: RenderCacheScene_051.png
+    m_size: 51125
+  - m_name: RenderCacheScene_052.png
+    m_size: 51056
+  - m_name: RenderCacheScene_053.png
+    m_size: 50666
+  - m_name: RenderCacheScene_054.png
+    m_size: 50533
+  - m_name: RenderCacheScene_055.png
+    m_size: 50273
+  - m_name: RenderCacheScene_056.png
+    m_size: 50105
+  - m_name: RenderCacheScene_057.png
+    m_size: 49767
+  - m_name: RenderCacheScene_058.png
+    m_size: 49763
+  - m_name: RenderCacheScene_059.png
+    m_size: 49425
+  - m_name: RenderCacheScene_060.png
+    m_size: 49131
+  - m_name: RenderCacheScene_061.png
+    m_size: 48331
+  - m_name: RenderCacheScene_062.png
+    m_size: 47965
+  - m_name: RenderCacheScene_063.png
+    m_size: 47819
+  - m_name: RenderCacheScene_064.png
+    m_size: 47772
+  - m_name: RenderCacheScene_065.png
+    m_size: 47449
+  - m_name: RenderCacheScene_066.png
+    m_size: 47001
+  - m_name: RenderCacheScene_067.png
+    m_size: 47227
+  - m_name: RenderCacheScene_068.png
+    m_size: 47548
+  - m_name: RenderCacheScene_069.png
+    m_size: 47742
+  - m_name: RenderCacheScene_070.png
+    m_size: 47485
+  - m_name: RenderCacheScene_071.png
+    m_size: 47807
+  - m_name: RenderCacheScene_072.png
+    m_size: 47949
+  - m_name: RenderCacheScene_073.png
+    m_size: 47900
+  - m_name: RenderCacheScene_074.png
+    m_size: 47772
+  - m_name: RenderCacheScene_075.png
+    m_size: 47778
+  - m_name: RenderCacheScene_076.png
+    m_size: 47697
+  - m_name: RenderCacheScene_077.png
+    m_size: 47409
+  - m_name: RenderCacheScene_078.png
+    m_size: 47490
+  - m_name: RenderCacheScene_079.png
+    m_size: 47116
+  - m_name: RenderCacheScene_080.png
+    m_size: 46941
+  - m_name: RenderCacheScene_081.png
+    m_size: 47189
+  - m_name: RenderCacheScene_082.png
+    m_size: 47198
+  - m_name: RenderCacheScene_083.png
+    m_size: 46899
+  - m_name: RenderCacheScene_084.png
+    m_size: 46853
+  - m_name: RenderCacheScene_085.png
+    m_size: 46697
+  - m_name: RenderCacheScene_086.png
+    m_size: 46789
+  - m_name: RenderCacheScene_087.png
+    m_size: 46354
+  - m_name: RenderCacheScene_088.png
+    m_size: 46427
+  - m_name: RenderCacheScene_089.png
+    m_size: 46380
+  - m_name: RenderCacheScene_090.png
+    m_size: 45938
+  - m_name: RenderCacheScene_091.png
+    m_size: 46253
+  - m_name: RenderCacheScene_092.png
+    m_size: 46112
+  - m_name: RenderCacheScene_093.png
+    m_size: 46327
+  - m_name: RenderCacheScene_094.png
+    m_size: 45993
+  - m_name: RenderCacheScene_095.png
+    m_size: 46202
+  - m_name: RenderCacheScene_096.png
+    m_size: 46015
+  - m_name: RenderCacheScene_097.png
+    m_size: 46073
+  - m_name: RenderCacheScene_098.png
+    m_size: 45844
+  - m_name: RenderCacheScene_099.png
+    m_size: 45967
+  - m_name: RenderCacheScene_100.png
+    m_size: 45916
+  m_updateBGColor: {r: 1, g: 0, b: 0, a: 1}
+  m_timelineBGColor: {r: 1, g: 1, b: 1, a: 1}
+  m_version: 2


### PR DESCRIPTION
Instead of always assigning a new one