### PR TITLE
chore: stop triggering dependency test jobs

### DIFF
--- a/.yamato/StreamingImageSequence-updated-dependencies-test.yml
+++ b/.yamato/StreamingImageSequence-updated-dependencies-test.yml
@@ -43,17 +43,17 @@ dependency_test_trigger:
     {{ yamato_name }}_dependency_test_packages:
       paths:
         - "upm-ci~/packages/**/*"    
-  triggers:
-    branches:
-      only:
-        - "/.*/"
-      except:
-        - "dev"
-        - "**/dev"
-    recurring:
-      - branch: dev
-        frequency: daily
-        rerun: on_new_revision
+#  triggers:
+#    branches:
+#      only:
+#        - "/.*/"
+#      except:
+#        - "dev"
+#        - "**/dev"
+#    recurring:
+#      - branch: dev
+#        frequency: daily
+#        rerun: on_new_revision
         
   dependencies:
     - .yamato/{{ yamato_name }}-pack.yml#pack


### PR DESCRIPTION
[skip ci]