### PR TITLE
fix: resolve merge conflict in Metadata

### DIFF
--- a/Runtime/Scripts.meta
+++ b/Runtime/Scripts.meta
@@ -1,9 +1,5 @@
 fileFormatVersion: 2
-<<<<<<< HEAD
 guid: 31a3d78afe593c54a823386b038b04ac
-=======
-guid: d0a5793ca42ad4fdf9f10d71a18e5232
->>>>>>> feat: initial implementation of RenderCache (#75)
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
Resolved a merge conflict in the asset file by removing duplicate GUID entries. 
The file now has a single GUID entry and is properly formatted.

Unity Editor is continuously displaying the following warning at regular intervals: 
```
The GUID inside 'Packages/com.unity.streaming-image-sequence/Runtime/Scripts.meta' cannot be extracted by the YAML Parser. Attempting to extract it via string matching instead.
``` 